### PR TITLE
Enable mobile views

### DIFF
--- a/Web/View/Communications/Index.hs
+++ b/Web/View/Communications/Index.hs
@@ -896,6 +896,7 @@ styles =
             .messages-list {
                 height: calc(var(--screen-height) - calc(var(--total-nav-height) + var(--message-input-height)));
                 overflow-y: scroll;
+                overflow-x: hidden;
             }
 
             .message-input {

--- a/Web/View/Communications/Index.hs
+++ b/Web/View/Communications/Index.hs
@@ -221,7 +221,7 @@ renderPage Page {..} =
                 </div>
                 <div id="messages" class="d-flex flex-column">
                     {renderSectionNavigation Communications selectedPerson}
-                    {renderMessagesColumn messagesColumn}
+                    {renderMobileMessagesColumn messagesColumn}
                     {renderColumnNavigation Messages}
                     <div class="browser-nav bg-light"></div>
                 </div>
@@ -521,8 +521,23 @@ renderMessagesColumn messagesColumn =
                 <div class="messages-list scroll-to-end">
                     {renderMessageItems messageItems scheduledMessageItems}
                 </div>
-                <div class="message-input pt-2 mb-xl-2">
+                <div class="message-input pt-2 mb-2">
                     {renderSendMessageForm sendMessageForm}
+                </div>
+            |]
+
+renderMobileMessagesColumn :: MessagesColumn -> Html
+renderMobileMessagesColumn messagesColumn =
+    case messagesColumn of
+        MessagesColumnNotVisible ->
+            [hsx||]
+        MessagesColumnVisible {..} ->
+            [hsx|
+                <div class="message-input pb-2">
+                    {renderSendMessageForm sendMessageForm}
+                </div>
+                <div class="messages-list">
+                    {renderMessageItems (reverse messageItems) (reverse scheduledMessageItems)}
                 </div>
             |]
 
@@ -549,7 +564,7 @@ renderMessageItem MessageItem {..} =
 
             <div class="d-flex w-100 justify-content-between">
                 <span class={statusClass}>{status}</span>
-                <a href={linkButtonAction}
+                <a href={pathTo linkButtonAction <> "#timecards"}
                     class={"btn btn-outline-primary btn-sm " <> linkButtonActiveClass}>
                     {linkButtonText}
                 </a>
@@ -817,7 +832,7 @@ renderFieldError (Just errorMessage) =
 renderColumnNavigation :: Column -> Html
 renderColumnNavigation currentColumn =
     [hsx|
-        <ul class="bottom-nav m-0 p-0 border bg-light d-flex">
+        <ul class="bottom-nav m-0 p-0 border-top bg-light d-flex">
             <li class="bottom-nav-item flex-even border-right d-flex justify-content-center">
                 <a class={"bottom-nav-link text-center " <> linkClass People} href="#people">People</a>
             </li>
@@ -863,7 +878,6 @@ styles =
 
             .communications-page {
                 height: var(--screen-height);
-                overflow-y: hidden;
             }
 
             .top-nav {
@@ -896,7 +910,6 @@ styles =
             .messages-list {
                 height: calc(var(--screen-height) - calc(var(--total-nav-height) + var(--message-input-height)));
                 overflow-y: scroll;
-                overflow-x: hidden;
             }
 
             .message-input {
@@ -977,6 +990,10 @@ styles =
 
             .flex-even {
                 flex: 1;
+            }
+
+            body {
+                overflow: hidden;
             }
         </style>
 

--- a/Web/View/Communications/Index.hs
+++ b/Web/View/Communications/Index.hs
@@ -938,7 +938,7 @@ styles =
             .message-body {
                 white-space: pre-line;
                 word-wrap: break-word;
-                word-break: break-all;
+                word-break: break-word;
             }
 
             .message-sent-at {

--- a/Web/View/Communications/Index.hs
+++ b/Web/View/Communications/Index.hs
@@ -10,7 +10,7 @@ import Web.View.Navigation.People
 import Web.View.Navigation.Section (Section (Communications), renderSectionNavigation)
 import Web.View.Prelude hiding (Page)
 import Web.View.Service.Style (removeScrollbars)
-import Web.View.Service.Time (formatDay)
+import Web.View.Service.Time (formatDateTime, formatDay)
 import Web.View.Timecards.Status
 
 data IndexView = IndexView
@@ -217,16 +217,19 @@ renderPage Page {..} =
                     {renderSectionNavigation Communications selectedPerson}
                     {renderPeopleNavigation peopleNavigation}
                     {renderColumnNavigation People}
+                    <div class="browser-nav bg-light"></div>
                 </div>
                 <div id="messages" class="d-flex flex-column">
                     {renderSectionNavigation Communications selectedPerson}
                     {renderMessagesColumn messagesColumn}
                     {renderColumnNavigation Messages}
+                    <div class="browser-nav bg-light"></div>
                 </div>
                 <div id="timecards" class="d-flex flex-column">
                     {renderSectionNavigation Communications selectedPerson}
                     {renderTimecardsColumn timecardColumn}
                     {renderColumnNavigation Timecards}
+                    <div class="browser-nav bg-light"></div>
                 </div>
             </div>
         </div>
@@ -284,7 +287,7 @@ buildMessageItem ::
 buildMessageItem selectedPerson personActivity selectedMessageIds message =
     MessageItem
         { fromName = get #fromFirstName message <> " " <> get #fromLastName message
-        , sentAt = show $ get #createdAt message
+        , sentAt = formatDateTime $ get #createdAt message
         , body = get #body message
         , statusClass = messageStatusClass'
         , status = messageStatus
@@ -351,7 +354,7 @@ buildScheduledMessageItem
 buildSuspendedScheduledMessageItem :: SendMessageAction.T -> ScheduledMessageItem
 buildSuspendedScheduledMessageItem scheduledMessage =
     SuspendedScheduledMessageItem
-        { runsAt = show $ get #runsAt scheduledMessage
+        { runsAt = formatDateTime $ get #runsAt scheduledMessage
         , body = get #body scheduledMessage
         , editAction = editAction
         , updateAction = updateAction
@@ -363,7 +366,7 @@ buildSuspendedScheduledMessageItem scheduledMessage =
 buildNotStartedScheduledMessageItem :: SendMessageAction.T -> ScheduledMessageItem
 buildNotStartedScheduledMessageItem scheduledMessage =
     NotStartedScheduledMessageItem
-        { runsAt = show $ get #runsAt scheduledMessage
+        { runsAt = formatDateTime $ get #runsAt scheduledMessage
         , body = get #body scheduledMessage
         , editAction = editAction
         , updateAction = updateAction
@@ -375,7 +378,7 @@ buildNotStartedScheduledMessageItem scheduledMessage =
 buildEditScheduledMessageForm :: Id Person -> SendMessageAction.T -> ScheduledMessageItem
 buildEditScheduledMessageForm selectedPersonId scheduledMessage =
     EditScheduledMessageForm
-        { runsAt = show $ get #runsAt scheduledMessage
+        { runsAt = formatDateTime $ get #runsAt scheduledMessage
         , body = get #body scheduledMessage
         , sendMessageActionId = show $ get #id scheduledMessage
         , saveAction = saveAction
@@ -836,6 +839,7 @@ styles =
             @media only screen and (min-width: 1200px) {
                 :root {
                     --bottom-nav-height: 0rem;
+                    --browser-nav-height: 0rem;
                 }
 
                 .timecards-block {
@@ -846,17 +850,19 @@ styles =
             @media only screen and (max-width: 1200px) {
                 :root {
                     --bottom-nav-height: 3rem;
+                    --browser-nav-height: 7rem;
                 }
             }
 
             :root {
                 --top-nav-height: 7.25rem;
-                --total-nav-height: calc(var(--top-nav-height) + var(--bottom-nav-height));
+                --total-nav-height: calc(var(--top-nav-height) + var(--bottom-nav-height) + var(--browser-nav-height));
                 --message-input-height: 5.8rem;
+                --screen-height: 100vh;
             }
 
             .communications-page {
-                height: 100vh;
+                height: var(--screen-height);
                 overflow-y: hidden;
             }
 
@@ -877,14 +883,18 @@ styles =
                 line-height: 2.5rem;
             }
 
+            .browser-nav {
+                height: var(--browser-nav-height);
+            }
+
             .people-list {
-                height: calc(100vh - var(--total-nav-height));
+                height: calc(var(--screen-height) - var(--total-nav-height));
                 min-width: 18.75rem;
                 overflow-y: scroll;
             }
 
             .messages-list {
-                height: calc(100vh - calc(var(--total-nav-height) + var(--message-input-height)));
+                height: calc(var(--screen-height) - calc(var(--total-nav-height) + var(--message-input-height)));
                 overflow-y: scroll;
             }
 
@@ -893,7 +903,7 @@ styles =
             }
 
             .timecards-block {
-                height: calc(100vh - var(--total-nav-height));
+                height: calc(var(--screen-height) - var(--total-nav-height));
                 overflow-y: scroll;
             }
 

--- a/Web/View/Communications/Index.hs
+++ b/Web/View/Communications/Index.hs
@@ -180,9 +180,9 @@ data TimecardEntryForm = TimecardEntryForm
     deriving (Eq, Show)
 
 data Column
-    = People
-    | Messages
-    | Timecards
+    = PeopleColumn
+    | MessagesColumn
+    | TimecardsColumn
     deriving (Eq, Show)
 
 instance View IndexView where
@@ -193,7 +193,7 @@ renderPage Page {..} =
     [hsx|
         <!-- Desktop version of the page. -->
         <div class="d-none d-xl-block">
-            <div class="communications-page d-flex flex-column">
+            <div class="d-flex flex-column">
                 {renderSectionNavigation Communications selectedPerson}
                 
                 <div class="d-flex flex-row">
@@ -212,23 +212,23 @@ renderPage Page {..} =
         
         <!-- Mobile version of the page. -->
         <div class="d-block d-xl-none">
-            <div class="communications-page d-flex flex-column">
+            <div class="d-flex flex-column">
                 <div id="people" class="d-flex flex-column">
                     {renderSectionNavigation Communications selectedPerson}
                     {renderPeopleNavigation peopleNavigation}
-                    {renderColumnNavigation People}
+                    {renderColumnNavigation PeopleColumn}
                     <div class="browser-nav bg-light"></div>
                 </div>
                 <div id="messages" class="d-flex flex-column">
                     {renderSectionNavigation Communications selectedPerson}
                     {renderMobileMessagesColumn messagesColumn}
-                    {renderColumnNavigation Messages}
+                    {renderColumnNavigation MessagesColumn}
                     <div class="browser-nav bg-light"></div>
                 </div>
                 <div id="timecards" class="d-flex flex-column">
                     {renderSectionNavigation Communications selectedPerson}
                     {renderTimecardsColumn timecardColumn}
-                    {renderColumnNavigation Timecards}
+                    {renderColumnNavigation TimecardsColumn}
                     <div class="browser-nav bg-light"></div>
                 </div>
             </div>
@@ -834,13 +834,13 @@ renderColumnNavigation currentColumn =
     [hsx|
         <ul class="bottom-nav m-0 p-0 border-top bg-light d-flex">
             <li class="bottom-nav-item flex-even border-right d-flex justify-content-center">
-                <a class={"bottom-nav-link text-center " <> linkClass People} href="#people">People</a>
+                <a class={"bottom-nav-link text-center " <> linkClass PeopleColumn} href="#people">People</a>
             </li>
             <li class="bottom-nav-item flex-even d-flex justify-content-center">
-                <a class={"bottom-nav-link text-center " <> linkClass Messages} href="#messages">Messages</a>
+                <a class={"bottom-nav-link text-center " <> linkClass MessagesColumn} href="#messages">Messages</a>
             </li>
             <li class="bottom-nav-item flex-even border-left d-flex justify-content-center">
-                <a class={"bottom-nav-link text-center " <> linkClass Timecards} href="#timecards">Timecards</a>
+                <a class={"bottom-nav-link text-center " <> linkClass TimecardsColumn} href="#timecards">Timecards</a>
             </li>
         </ul>
     |]
@@ -872,16 +872,8 @@ styles =
             :root {
                 --top-nav-height: 7.25rem;
                 --total-nav-height: calc(var(--top-nav-height) + var(--bottom-nav-height) + var(--browser-nav-height));
-                --message-input-height: 5.8rem;
+                --message-input-height: 7.0rem;
                 --screen-height: 100vh;
-            }
-
-            .communications-page {
-                height: var(--screen-height);
-            }
-
-            .top-nav {
-                height: var(--top-nav-height);
             }
 
             .bottom-nav {

--- a/Web/View/Communications/Index.hs
+++ b/Web/View/Communications/Index.hs
@@ -937,6 +937,8 @@ styles =
 
             .message-body {
                 white-space: pre-line;
+                word-wrap: break-word;
+                word-break: break-all;
             }
 
             .message-sent-at {

--- a/Web/View/Communications/Index.hs
+++ b/Web/View/Communications/Index.hs
@@ -878,7 +878,6 @@ styles =
 
             .communications-page {
                 height: var(--screen-height);
-                overflow: hidden;
             }
 
             .top-nav {
@@ -910,6 +909,7 @@ styles =
 
             .messages-list {
                 height: calc(var(--screen-height) - calc(var(--total-nav-height) + var(--message-input-height)));
+                overflow-x: hidden;
                 overflow-y: scroll;
             }
 

--- a/Web/View/Communications/Index.hs
+++ b/Web/View/Communications/Index.hs
@@ -878,6 +878,7 @@ styles =
 
             .communications-page {
                 height: var(--screen-height);
+                overflow: hidden;
             }
 
             .top-nav {

--- a/Web/View/Layout.hs
+++ b/Web/View/Layout.hs
@@ -22,7 +22,7 @@ defaultLayout inner =
     <title>Constructable</title>
 </head>
 <body>
-    <div class="content container-fluid">
+    <div class="content container-fluid p-0 m-0">
         {renderFlashMessages}
         {inner}
     </div>

--- a/Web/View/Navigation/Section.hs
+++ b/Web/View/Navigation/Section.hs
@@ -11,10 +11,10 @@ data Section
 renderSectionNavigation :: Section -> Maybe Person -> Html
 renderSectionNavigation currentSection selectedPerson =
     [hsx|
-        <nav class="navbar navbar-expand navbar-light bg-light">
+        <nav class="navbar navbar-expand navbar-light bg-light m-0 mb-3">
             <div class="container-fluid">
-                <span class="navbar-brand mb-0 h1" href="#">Constructable</span>
-                <div class="collapse navbar-collapse" id="navbarSupportedContent">
+                <span class="navbar-brand mb-0 h1 d-none d-lg-inline" href="#">Constructable</span>
+                <div class="collapse navbar-collapse">
                     <ul class="navbar-nav mb-0">
                         {renderItem timecardsAction Timecards "Timecards" currentSection}
                         {renderItem communicationsAction Communications "Communications" currentSection}

--- a/Web/View/Service/Time.hs
+++ b/Web/View/Service/Time.hs
@@ -21,7 +21,7 @@ formatTimeOfDay timeOfDay =
     strip $ pack $ formatTime defaultTimeLocale "%l:%M %p" timeOfDay
 
 formatDateTime :: UTCTime -> Text
-formatDateTime time = strip $ pack $ formatTime defaultTimeLocale "%FT%X" time
+formatDateTime time = strip $ pack $ formatTime defaultTimeLocale "%FT%X%z" time
 
 weekday :: UTCTime -> Html
 weekday = timeElement "weekday"

--- a/Web/View/Service/Time.hs
+++ b/Web/View/Service/Time.hs
@@ -1,6 +1,7 @@
 module Web.View.Service.Time (
     formatDay,
     formatTimeOfDay,
+    formatDateTime,
     weekday,
 ) where
 
@@ -18,6 +19,9 @@ formatDay = pack . formatTime defaultTimeLocale "%m/%d/%Y"
 formatTimeOfDay :: TimeOfDay -> Text
 formatTimeOfDay timeOfDay =
     strip $ pack $ formatTime defaultTimeLocale "%l:%M %p" timeOfDay
+
+formatDateTime :: UTCTime -> Text
+formatDateTime time = strip $ pack $ formatTime defaultTimeLocale "%FT%X" time
 
 weekday :: UTCTime -> Html
 weekday = timeElement "weekday"

--- a/Web/View/Timecards/Index.hs
+++ b/Web/View/Timecards/Index.hs
@@ -96,6 +96,7 @@ buildPage view =
             buildPeopleNavigation
                 BadgesHidden
                 TimecardPersonSelectionAction
+                NoAnchor
                 selectedPerson
                 (get #people view)
         , timecardColumn = buildTimecardColumn view
@@ -199,22 +200,22 @@ renderPage Page {..} =
     [hsx|
             {renderSectionNavigation Timecards selectedPerson}
 
-            <div class="row align-items start">
+            <div class="d-flex">
                 {renderPeopleNavigation peopleNavigation}
-                {renderTimecardColumn2 timecardColumn}
+                {renderTimecardColumn timecardColumn}
             </div>
 
             {styles}
         |]
 
-renderTimecardColumn2 :: TimecardColumn -> Html
-renderTimecardColumn2 timecardColumn =
+renderTimecardColumn :: TimecardColumn -> Html
+renderTimecardColumn timecardColumn =
     case timecardColumn of
         TimecardColumnNotVisible ->
             [hsx||]
         TimecardColumnVisible {..} ->
             [hsx|
-                <div class="timecard-column col-10">
+                <div class="timecard-column m-3 flex-grow-1">
                     {forEach timecardTables renderTimecardTable}
                 </div>
             |]
@@ -226,7 +227,7 @@ renderTimecardTable TimecardTable {..} =
             <div class="card-header d-flex justify-content-start mb-2">
                 <h5>Week Of {weekOf}</h5>
                 <div class="ml-2">
-                    {renderTimecardStatus2 status}
+                    {renderTimecardStatus status}
                 </div>
             </div>
             
@@ -259,8 +260,8 @@ renderTimecardTable TimecardTable {..} =
         </div>
     |]
 
-renderTimecardStatus2 :: TimecardStatus -> Html
-renderTimecardStatus2 TimecardStatus {..} =
+renderTimecardStatus :: TimecardStatus -> Html
+renderTimecardStatus TimecardStatus {..} =
     [hsx|
         <span class={statusClasses}>
             {statusLabel}
@@ -353,8 +354,13 @@ styles :: Html
 styles =
     [hsx|
         <style>
-            .people-column {
-                height: calc(100vh - 150px);
+            :root {
+                --top-nav-height: 7.25rem;
+            }
+
+            .people-list {
+                height: calc(100vh - var(--top-nav-height));
+                min-width: 18.75rem;
                 overflow-y: scroll;
             }
 

--- a/Web/View/Timecards/Index.hs
+++ b/Web/View/Timecards/Index.hs
@@ -85,6 +85,11 @@ data InvoiceTranslationCell
         }
     deriving (Eq, Show)
 
+data Column
+    = PeopleColumn
+    | TimecardsColumn
+    deriving (Eq, Show)
+
 instance View IndexView where
     html view = renderPage $ buildPage view
 
@@ -198,11 +203,30 @@ buildTotalHoursRow timecardEntries =
 renderPage :: Page -> Html
 renderPage Page {..} =
     [hsx|
-            {renderSectionNavigation Timecards selectedPerson}
+            <div class="d-none d-xl-block">
+                {renderSectionNavigation Timecards selectedPerson}
 
-            <div class="d-flex">
-                {renderPeopleNavigation peopleNavigation}
-                {renderTimecardColumn timecardColumn}
+                <div class="d-flex flex-row">
+                    {renderPeopleNavigation peopleNavigation}
+                    {renderTimecardColumn timecardColumn}
+                </div>
+            </div>
+
+            <div class="d-block d-xl-none">
+                <div class="d-flex flex-column">
+                    <div id="people" class="d-flex flex-column">
+                        {renderSectionNavigation Timecards selectedPerson}
+                        {renderPeopleNavigation peopleNavigation}
+                        {renderColumnNavigation PeopleColumn}
+                        <div class="browser-nav bg-light"></div>
+                    </div>
+                    <div id="timecards" class="d-flex flex-column">
+                        {renderSectionNavigation Timecards selectedPerson}
+                        {renderTimecardColumn timecardColumn}
+                        {renderColumnNavigation TimecardsColumn}
+                        <div class="browser-nav bg-light"></div>
+                    </div>
+                </div>
             </div>
 
             {styles}
@@ -215,7 +239,7 @@ renderTimecardColumn timecardColumn =
             [hsx||]
         TimecardColumnVisible {..} ->
             [hsx|
-                <div class="timecard-column m-3 flex-grow-1">
+                <div class="timecards-column m-xl-3 flex-grow-1">
                     {forEach timecardTables renderTimecardTable}
                 </div>
             |]
@@ -240,13 +264,13 @@ renderTimecardTable TimecardTable {..} =
                     <thead>
                         <tr>
                             <th scope="col">Day</th>
-                            <th scope="col">Date</th>
+                            <th scope="col" class="d-none d-md-table-cell">Date</th>
                             <th scope="col">Job</th>
-                            <th scope="col">Clock In</th>
-                            <th scope="col">Clock Out</th>
-                            <th scope="col">Lunch (mins)</th>
-                            <th scope="col">Work Done</th>
-                            <th scope="col">Invoice Translation</th>
+                            <th scope="col" class="d-none d-md-table-cell">Clock In</th>
+                            <th scope="col" class="d-none d-md-table-cell">Clock Out</th>
+                            <th scope="col" class="d-none d-md-table-cell">Lunch (mins)</th>
+                            <th scope="col" class="d-none d-md-table-cell">Work Done</th>
+                            <th scope="col" class="d-none d-md-table-cell">Invoice Translation</th>
                             <th scope="col">Hours</th>
                         </tr>
                     </thead>
@@ -273,12 +297,12 @@ renderJobRow JobRow {..} =
     [hsx|
         <tr>
             <th scope="row">{dayOfWeek'}</th>
-            <td>{date}</td>
+            <td class="d-none d-md-table-cell">{date}</td>
             <td>{jobName}</td>
-            <td>{clockedInAt}</td>
-            <td>{clockedOutAt}</td>
-            <td>{lunchDuration}</td>
-            <td class="work-done">{workDone}</td>
+            <td class="d-none d-md-table-cell">{clockedInAt}</td>
+            <td class="d-none d-md-table-cell">{clockedOutAt}</td>
+            <td class="d-none d-md-table-cell">{lunchDuration}</td>
+            <td class="work-done d-none d-md-table-cell">{workDone}</td>
             {renderInvoiceTranslationCell invoiceTranslationCell}
             <td>{hoursWorked}</td>
         </tr>
@@ -289,54 +313,22 @@ renderInvoiceTranslationCell invoiceTranslationCell =
     case invoiceTranslationCell of
         ShowInvoiceTranslation {..} ->
             [hsx|
-                <td class="invoice-translation">
+                <td class="invoice-translation d-none d-md-table-cell">
                     {invoiceTranslation} (<a href={editAction}>Edit</a>)
                 </td>
             |]
         EditInvoiceTranslation {..} ->
             [hsx|
-                <td class="invoice-translation">
-                    <form method="POST" 
-                        action={saveAction} id="edit-timecard-entry-form"
-                        class="edit-form"
-                        data-disable-javascript-submission="false">
-                        
-                        <div
-                            class="form-group"
-                            id="form-group-timecardEntry_invoiceTranslation">
-                            <textarea
-                                type="text"
-                                name="invoiceTranslation"
-                                placeholder=""
-                                id="timecardEntry_invoiceTranslation"
-                                class="form-control"
-                                value={invoiceTranslation}>
+                <td class="invoice-translation d-none d-md-table-cell">
+                    <form method="POST" action={saveAction} class="edit-form" data-disable-javascript-submission="false">
+                        <div class="form-group">
+                            <textarea type="text" name="invoiceTranslation" placeholder="" class="invoice-translation-input form-control" value={invoiceTranslation}>
                                 {invoiceTranslation}
                             </textarea> 
                         </div>
                         
-                        <div
-                            class="form-group"
-                            id="form-group-timecardEntry_id">
-                            <input
-                                type="hidden"
-                                name="id"
-                                placeholder=""
-                                id="timecardEntry_id"
-                                class="form-control"
-                                value={timecardEntryId}>
-                        </div>
-                        
-                        <button
-                            class="btn btn-primary btn btn-primary btn-sm">
-                            Save
-                        </button>
-                        
-                        <a 
-                            href={cancelAction}
-                            class="btn btn-secondary btn-sm ml-2">
-                            Cancel
-                        </a>
+                        <button class="btn btn-primary btn btn-primary btn-sm">Save</button>
+                        <a href={cancelAction} class="btn btn-secondary btn-sm ml-2">Cancel</a>
                     </form>
                 </td>
             |]
@@ -345,27 +337,82 @@ renderTotalHoursRow :: TotalHoursRow -> Html
 renderTotalHoursRow TotalHoursRow {..} =
     [hsx|
         <tr class="table-active">
-            <th scope="row" colspan="8">Total Hours</th>
+            <th scope="row">Total Hours</th>
+            <td class="d-none d-md-table-cell"></td>
+            <td></td>
+            <td class="d-none d-md-table-cell"></td>
+            <td class="d-none d-md-table-cell"></td>
+            <td class="d-none d-md-table-cell"></td>
+            <td class="d-none d-md-table-cell"></td>
+            <td class="d-none d-md-table-cell"></td>
             <td>{totalHours}</td>
         </tr>
     |]
+
+renderColumnNavigation :: Column -> Html
+renderColumnNavigation currentColumn =
+    [hsx|
+        <ul class="bottom-nav m-0 p-0 border-top bg-light d-flex">
+            <li class="bottom-nav-item flex-even border-right d-flex justify-content-center">
+                <a class={"bottom-nav-link text-center " <> linkClass PeopleColumn} href="#people">People</a>
+            </li>
+            <li class="bottom-nav-item flex-even border-left d-flex justify-content-center">
+                <a class={"bottom-nav-link text-center " <> linkClass TimecardsColumn} href="#timecards">Timecards</a>
+            </li>
+        </ul>
+    |]
+  where
+    linkClass column = if column == currentColumn then "text-dark" :: Text else "text-muted"
 
 styles :: Html
 styles =
     [hsx|
         <style>
+            @media only screen and (min-width: 1200px) {
+                :root {
+                    --bottom-nav-height: 0rem;
+                    --browser-nav-height: 0rem;
+                }
+            }
+
+            @media only screen and (max-width: 1200px) {
+                :root {
+                    --bottom-nav-height: 3rem;
+                    --browser-nav-height: 7rem;
+                }
+            }
+
             :root {
                 --top-nav-height: 7.25rem;
+                --total-nav-height: calc(var(--top-nav-height) + var(--bottom-nav-height) + var(--browser-nav-height));
+                --screen-height: 100vh;
+            }
+
+            .bottom-nav {
+                height: var(--bottom-nav-height);
+            }
+
+            .bottom-nav-item {
+                list-style-type: none;
+            }
+
+            .bottom-nav-link {
+                width: 100%;
+                line-height: 2.5rem;
+            }
+
+            .browser-nav {
+                height: var(--browser-nav-height);
             }
 
             .people-list {
-                height: calc(100vh - var(--top-nav-height));
+                height: calc(var(--screen-height) - var(--total-nav-height));
                 min-width: 18.75rem;
                 overflow-y: scroll;
             }
 
-            .timecard-column {
-                height: calc(100vh - 150px);
+            .timecards-column {
+                height: calc(var(--screen-height) - var(--total-nav-height));
                 overflow-y: scroll;
                 font-size: .9rem;
             }
@@ -379,16 +426,24 @@ styles =
             }
 
             .work-done {
-                width: 300px;
+                width: 18.75rem;
             }
 
             .invoice-translation {
-                width: 300px;
+                width: 18.75rem;
             }
 
-            #timecardEntry_invoiceTranslation {
+            .invoice-translation-input.form-control {
                 font-size: .9rem;
-                height: 150px;
+                height: 9.4rem;
+            }
+
+            .flex-even {
+                flex: 1;
+            }
+
+            body {
+                overflow: hidden;
             }
         </style>
 

--- a/Web/View/Timecards/Index.hs
+++ b/Web/View/Timecards/Index.hs
@@ -101,7 +101,7 @@ buildPage view =
             buildPeopleNavigation
                 BadgesHidden
                 TimecardPersonSelectionAction
-                NoAnchor
+                (Anchor "timecards")
                 selectedPerson
                 (get #people view)
         , timecardColumn = buildTimecardColumn view

--- a/static/app.js
+++ b/static/app.js
@@ -1,7 +1,7 @@
 function scrollToEnd() {
     let elements = $('.scroll-to-end');
     for (let i = 0; i < elements.length; i++) {
-        elements[i].scrollTop = Number.MAX_SAFE_INTEGER;
+        elements[i].scrollTop = 1000000000;
     }
 }
 

--- a/static/app.js
+++ b/static/app.js
@@ -1,7 +1,7 @@
-function scrollToPinned() {
-    let anchors = $('.scroll-pinned');
-    for (let i = 0; i < anchors.length; i++) {
-        anchors[i].scrollIntoView();
+function scrollToEnd() {
+    let elements = $('.scroll-to-end');
+    for (let i = 0; i < elements.length; i++) {
+        elements[i].scrollTop = Number.MAX_SAFE_INTEGER;
     }
 }
 
@@ -46,8 +46,8 @@ function initCustomTime() {
 }
 
 function initApp() {
-    // For anything marked as 'scroll-pinned', scroll to it on page load
-    scrollToPinned();
+    // For anything with class 'scroll-to-end', scroll that element to the end on page load
+    scrollToEnd();
 
     // Reformat time elements based on locale whenever page changes occur
     initTime();

--- a/test/Web/View/Communications/IndexSpec.hs
+++ b/test/Web/View/Communications/IndexSpec.hs
@@ -51,6 +51,7 @@ spec = do
                                     CommunicationsPersonSelectionAction
                                         { selectedPersonId = "10000000-0000-0000-0000-000000000000"
                                         }
+                                , anchor = "messages"
                                 , activeClass = ""
                                 , ariaCurrent = "false"
                                 , firstName = "Barbara"
@@ -66,6 +67,7 @@ spec = do
                                     CommunicationsPersonSelectionAction
                                         { selectedPersonId = "20000000-0000-0000-0000-000000000000"
                                         }
+                                , anchor = "messages"
                                 , activeClass = ""
                                 , ariaCurrent = "false"
                                 , firstName = "Jackie"

--- a/test/Web/View/Communications/IndexSpec.hs
+++ b/test/Web/View/Communications/IndexSpec.hs
@@ -176,7 +176,7 @@ spec = do
                     { messageItems =
                         [ Index.MessageItem
                             { fromName = "Barbara Bush"
-                            , sentAt = "2021-06-23 22:29:00 UTC"
+                            , sentAt = "2021-06-23T22:29:00+0000"
                             , body = "What's up?"
                             , statusClass = "message-status delivered"
                             , status = "Delivered"
@@ -193,7 +193,7 @@ spec = do
                             }
                         , Index.MessageItem
                             { fromName = "Jackie Kennedy"
-                            , sentAt = "2021-06-23 22:30:00 UTC"
+                            , sentAt = "2021-06-23T22:30:00+0000"
                             , body = "Not much."
                             , statusClass = "message-status delivered"
                             , status = "Delivered"
@@ -211,7 +211,7 @@ spec = do
                         ]
                     , scheduledMessageItems =
                         [ Index.NotStartedScheduledMessageItem
-                            { runsAt = "2021-06-23 22:30:00 UTC"
+                            { runsAt = "2021-06-23T22:30:00+0000"
                             , body = "Hello World!"
                             , editAction =
                                 CommunicationsEditScheduledMessageAction
@@ -300,7 +300,7 @@ spec = do
                 [twilioMessage1, twilioMessage2]
                 `shouldBe` [ Index.MessageItem
                                 { fromName = "Barbara Bush"
-                                , sentAt = "2021-06-23 22:29:00 UTC"
+                                , sentAt = "2021-06-23T22:29:00+0000"
                                 , body = "What's up?"
                                 , statusClass = "message-status delivered"
                                 , status = "Delivered"
@@ -317,7 +317,7 @@ spec = do
                                 }
                            , Index.MessageItem
                                 { fromName = "Jackie Kennedy"
-                                , sentAt = "2021-06-23 22:30:00 UTC"
+                                , sentAt = "2021-06-23T22:30:00+0000"
                                 , body = "Not much."
                                 , statusClass = "message-status delivered"
                                 , status = "Delivered"
@@ -384,7 +384,7 @@ spec = do
                 [twilioMessage1, twilioMessage2]
                 `shouldBe` [ Index.MessageItem
                                 { fromName = "Barbara Bush"
-                                , sentAt = "2021-06-23 22:29:00 UTC"
+                                , sentAt = "2021-06-23T22:29:00+0000"
                                 , body = "What's up?"
                                 , statusClass = "message-status delivered"
                                 , status = "Delivered"
@@ -402,7 +402,7 @@ spec = do
                                 }
                            , Index.MessageItem
                                 { fromName = "Jackie Kennedy"
-                                , sentAt = "2021-06-23 22:30:00 UTC"
+                                , sentAt = "2021-06-23T22:30:00+0000"
                                 , body = "Not much."
                                 , statusClass = "message-status delivered"
                                 , status = "Delivered"
@@ -450,7 +450,7 @@ spec = do
                 twilioMessage
                 `shouldBe` Index.MessageItem
                     { fromName = "Barbara Bush"
-                    , sentAt = "2021-06-23 22:29:00 UTC"
+                    , sentAt = "2021-06-23T22:29:00+0000"
                     , body = "What's up?"
                     , statusClass = "message-status delivered"
                     , status = "Delivered"
@@ -501,7 +501,7 @@ spec = do
                 twilioMessage
                 `shouldBe` Index.MessageItem
                     { fromName = "Barbara Bush"
-                    , sentAt = "2021-06-23 22:29:00 UTC"
+                    , sentAt = "2021-06-23T22:29:00+0000"
                     , body = "What's up?"
                     , statusClass = "message-status delivered"
                     , status = "Delivered"
@@ -558,7 +558,7 @@ spec = do
                 twilioMessage
                 `shouldBe` Index.MessageItem
                     { fromName = "Barbara Bush"
-                    , sentAt = "2021-06-23 22:29:00 UTC"
+                    , sentAt = "2021-06-23T22:29:00+0000"
                     , body = "What's up?"
                     , statusClass = "message-status delivered"
                     , status = "Delivered"
@@ -612,7 +612,7 @@ spec = do
                 "50000000-0000-0000-0000-000000000000"
                 sendMessageAction
                 `shouldBe` Index.NotStartedScheduledMessageItem
-                    { runsAt = "2021-06-23 22:30:00 UTC"
+                    { runsAt = "2021-06-23T22:30:00+0000"
                     , body = "Hello World!"
                     , editAction =
                         CommunicationsEditScheduledMessageAction
@@ -643,7 +643,7 @@ spec = do
                 "50000000-0000-0000-0000-000000000000"
                 sendMessageAction
                 `shouldBe` Index.SuspendedScheduledMessageItem
-                    { runsAt = "2021-06-23 22:30:00 UTC"
+                    { runsAt = "2021-06-23T22:30:00+0000"
                     , body = "Hello World!"
                     , editAction =
                         CommunicationsEditScheduledMessageAction
@@ -674,7 +674,7 @@ spec = do
                 "50000000-0000-0000-0000-000000000000"
                 sendMessageAction
                 `shouldBe` Index.EditScheduledMessageForm
-                    { runsAt = "2021-06-23 22:30:00 UTC"
+                    { runsAt = "2021-06-23T22:30:00+0000"
                     , body = "Hello World!"
                     , sendMessageActionId = "10000000-0000-0000-0000-000000000000"
                     , saveAction =

--- a/test/Web/View/Navigation/PeopleSpec.hs
+++ b/test/Web/View/Navigation/PeopleSpec.hs
@@ -48,6 +48,7 @@ spec = do
             buildPeopleNavigation
                 BadgesHidden
                 DummyControllerAction
+                NoAnchor
                 (Just selectedPerson)
                 people
                 `shouldBe` PeopleNavigation
@@ -57,6 +58,7 @@ spec = do
                                 DummyControllerAction
                                     { selectedPersonId = "10000000-0000-0000-0000-000000000000"
                                     }
+                            , anchor = ""
                             , activeClass = "active"
                             , ariaCurrent = "true"
                             , firstName = "Barbara"
@@ -68,6 +70,7 @@ spec = do
                                 DummyControllerAction
                                     { selectedPersonId = "20000000-0000-0000-0000-000000000000"
                                     }
+                            , anchor = ""
                             , activeClass = ""
                             , ariaCurrent = "false"
                             , firstName = "Jackie"
@@ -101,6 +104,7 @@ spec = do
             buildPeopleNavigation
                 BadgesHidden
                 DummyControllerAction
+                NoAnchor
                 Nothing
                 people
                 `shouldBe` PeopleNavigation
@@ -110,6 +114,7 @@ spec = do
                                 DummyControllerAction
                                     { selectedPersonId = "10000000-0000-0000-0000-000000000000"
                                     }
+                            , anchor = ""
                             , activeClass = ""
                             , ariaCurrent = "false"
                             , firstName = "Barbara"
@@ -121,6 +126,7 @@ spec = do
                                 DummyControllerAction
                                     { selectedPersonId = "20000000-0000-0000-0000-000000000000"
                                     }
+                            , anchor = ""
                             , activeClass = ""
                             , ariaCurrent = "false"
                             , firstName = "Jackie"
@@ -154,6 +160,7 @@ spec = do
             buildPeopleNavigation
                 BadgesVisible
                 DummyControllerAction
+                NoAnchor
                 Nothing
                 people
                 `shouldBe` PeopleNavigation
@@ -163,6 +170,7 @@ spec = do
                                 DummyControllerAction
                                     { selectedPersonId = "10000000-0000-0000-0000-000000000000"
                                     }
+                            , anchor = ""
                             , activeClass = ""
                             , ariaCurrent = "false"
                             , firstName = "Barbara"
@@ -178,6 +186,7 @@ spec = do
                                 DummyControllerAction
                                     { selectedPersonId = "20000000-0000-0000-0000-000000000000"
                                     }
+                            , anchor = ""
                             , activeClass = ""
                             , ariaCurrent = "false"
                             , firstName = "Jackie"
@@ -205,10 +214,38 @@ spec = do
             buildPersonItem
                 BadgesHidden
                 DummyControllerAction
+                NoAnchor
                 False
                 person
                 `shouldBe` PersonItem
                     { selectionAction = DummyControllerAction "10000000-0000-0000-0000-000000000000"
+                    , anchor = ""
+                    , activeClass = ""
+                    , ariaCurrent = "false"
+                    , firstName = "Barbara"
+                    , lastName = "Bush"
+                    , stateBadge = HiddenBadge
+                    }
+
+        it "returns a person item with the correct anchor when one is specified" do
+            let person =
+                    People.View.Person
+                        { id = "10000000-0000-0000-0000-000000000000"
+                        , firstName = "Barbara"
+                        , lastName = "Bush"
+                        , goesBy = "Barb"
+                        , state = People.View.PersonIdle
+                        }
+
+            buildPersonItem
+                BadgesHidden
+                DummyControllerAction
+                (Anchor "something")
+                False
+                person
+                `shouldBe` PersonItem
+                    { selectionAction = DummyControllerAction "10000000-0000-0000-0000-000000000000"
+                    , anchor = "something"
                     , activeClass = ""
                     , ariaCurrent = "false"
                     , firstName = "Barbara"
@@ -229,12 +266,14 @@ spec = do
             buildPersonItem
                 BadgesHidden
                 DummyControllerAction
+                NoAnchor
                 True
                 person
                 `shouldBe` PersonItem
                     { selectionAction =
                         DummyControllerAction
                             "10000000-0000-0000-0000-000000000000"
+                    , anchor = ""
                     , activeClass = "active"
                     , ariaCurrent = "true"
                     , firstName = "Barbara"
@@ -255,10 +294,12 @@ spec = do
             buildPersonItem
                 BadgesVisible
                 DummyControllerAction
+                NoAnchor
                 False
                 person
                 `shouldBe` PersonItem
                     { selectionAction = DummyControllerAction "10000000-0000-0000-0000-000000000000"
+                    , anchor = ""
                     , activeClass = ""
                     , ariaCurrent = "false"
                     , firstName = "Barbara"

--- a/test/Web/View/Timecards/IndexSpec.hs
+++ b/test/Web/View/Timecards/IndexSpec.hs
@@ -64,6 +64,7 @@ spec = do
                                         TimecardPersonSelectionAction
                                             { selectedPersonId = "10000000-0000-0000-0000-000000000000"
                                             }
+                                    , anchor = ""
                                     , activeClass = ""
                                     , ariaCurrent = "false"
                                     , firstName = "John"

--- a/test/Web/View/Timecards/IndexSpec.hs
+++ b/test/Web/View/Timecards/IndexSpec.hs
@@ -64,7 +64,7 @@ spec = do
                                         TimecardPersonSelectionAction
                                             { selectedPersonId = "10000000-0000-0000-0000-000000000000"
                                             }
-                                    , anchor = ""
+                                    , anchor = "timecards"
                                     , activeClass = ""
                                     , ariaCurrent = "false"
                                     , firstName = "John"


### PR DESCRIPTION
This PR makes timecard usable on mobile devices by focusing on a single column and hiding the others on both the communications and timecards pages. It includes a local navigation bar at the bottom of the page which allows the user to jump around to different columns on the same page.