### PR TITLE
Automate timecard review signature

### DIFF
--- a/Application/Brain/Act.hs
+++ b/Application/Brain/Act.hs
@@ -13,7 +13,7 @@ act Decide.SuspendReminder {..} = do
     actionRunState <- fetch actionRunStateId
     ActionRunState.updateSuspended actionRunState
     pure ()
-act Decide.CreateTimecardEntryAndScheduleReminder {..} = do
+act Decide.CreateTimecardEntry {..} = do
     worker <- fetch workerId
 
     let timecardEntry =

--- a/Application/Brain/Act.hs
+++ b/Application/Brain/Act.hs
@@ -4,15 +4,17 @@ import qualified Application.Action.ActionRunState as ActionRunState
 import Application.Brain.Decide as Decide
 import qualified Application.Timecard.Entry as Entry
 import qualified Application.Timecard.EntryRequest as EntryRequest
+import qualified Application.Timecard.Query as Timecard.Query
+import qualified Application.Timecard.ReviewRequest as ReviewRequest
+import qualified Application.Timecard.View as Timecard.View
 import Generated.Types
 import IHP.ControllerPrelude
-import IHP.Prelude
 
-act :: (?modelContext :: ModelContext) => Decide.Plan -> IO ()
-act Decide.SuspendScheduledMessages {..} = do
+act :: (?modelContext :: ModelContext) => Text -> Decide.Plan -> IO ()
+act _ Decide.SuspendScheduledMessages {..} = do
     actionRunState <- fetch actionRunStateIds
     mapM_ ActionRunState.updateSuspended actionRunState
-act Decide.CreateTimecardEntry {..} = do
+act baseUrl Decide.CreateTimecardEntry {..} = do
     worker <- fetch workerId
 
     let timecardEntry =
@@ -33,7 +35,6 @@ act Decide.CreateTimecardEntry {..} = do
             timecardEntry
 
     case timecardEntry of
-        Left _ -> pure ()
         Right timecardEntry -> do
             EntryRequest.scheduleNextRequest
                 companyTimeZone
@@ -42,6 +43,29 @@ act Decide.CreateTimecardEntry {..} = do
                 worker
                 botPhoneNumberId
                 workerPhoneNumberId
-            pure ()
-act DoNothing =
+
+            let timecardId = get #timecardId timecardEntry
+            readyForReview <- isTimecardReadyForReview timecardId
+            when
+                readyForReview
+                ( ReviewRequest.scheduleRequest
+                    baseUrl
+                    now
+                    timecardId
+                    (get #goesBy worker)
+                    botPhoneNumberId
+                    workerPhoneNumberId
+                    >> pure ()
+                )
+        Left _ -> pure ()
+act _ DoNothing =
     pure ()
+
+isTimecardReadyForReview :: (?modelContext :: ModelContext) => Id Timecard -> IO Bool
+isTimecardReadyForReview timecardId = do
+    rows <- Timecard.Query.fetchById Timecard.Query.EntriesDateAscending timecardId
+    case Timecard.View.buildTimecard rows of
+        Just timecard ->
+            pure $ get #status timecard == Timecard.View.TimecardReadyForReview
+        Nothing ->
+            pure False

--- a/Application/Brain/Act.hs
+++ b/Application/Brain/Act.hs
@@ -9,7 +9,7 @@ import IHP.ControllerPrelude
 import IHP.Prelude
 
 act :: (?modelContext :: ModelContext) => Decide.Plan -> IO ()
-act Decide.SuspendReminder {..} = do
+act Decide.SuspendScheduledMessages {..} = do
     actionRunState <- fetch actionRunStateId
     ActionRunState.updateSuspended actionRunState
     pure ()

--- a/Application/Brain/Act.hs
+++ b/Application/Brain/Act.hs
@@ -10,9 +10,8 @@ import IHP.Prelude
 
 act :: (?modelContext :: ModelContext) => Decide.Plan -> IO ()
 act Decide.SuspendScheduledMessages {..} = do
-    actionRunState <- fetch actionRunStateId
-    ActionRunState.updateSuspended actionRunState
-    pure ()
+    actionRunState <- fetch actionRunStateIds
+    mapM_ ActionRunState.updateSuspended actionRunState
 act Decide.CreateTimecardEntry {..} = do
     worker <- fetch workerId
 

--- a/Application/Brain/Decide.hs
+++ b/Application/Brain/Decide.hs
@@ -21,7 +21,7 @@ data Plan
         , workDone :: !Text
         , invoiceTranslation :: !Text
         }
-    | SuspendReminder
+    | SuspendScheduledMessages
         { actionRunStateId :: !(Id ActionRunState)
         }
     | DoNothing
@@ -43,6 +43,6 @@ decide Orient.Situation {..} =
                 Orient.UpdateDetailsDoNotMatch -> DoNothing
                 Orient.MessageIsNotAnUpdate -> DoNothing
         Orient.ReminderIsScheduled {..} ->
-            SuspendReminder {..}
+            SuspendScheduledMessages {..}
         Orient.ReminderIsSuspended ->
             DoNothing

--- a/Application/Brain/Decide.hs
+++ b/Application/Brain/Decide.hs
@@ -5,7 +5,7 @@ import Generated.Types
 import IHP.Prelude
 
 data Plan
-    = CreateTimecardEntryAndScheduleReminder
+    = CreateTimecardEntry
         { now :: !UTCTime
         , companyTimeZone :: !TimeZone
         , workerId :: !(Id Person)
@@ -33,7 +33,7 @@ decide Orient.Situation {..} =
         Orient.ReminderIsNotScheduled ->
             case update of
                 Orient.UpdateIsForASingleJob Orient.Job {..} ->
-                    CreateTimecardEntryAndScheduleReminder
+                    CreateTimecardEntry
                         { jobName = name
                         , linkedMessageId = twilioMessageId
                         , ..

--- a/Application/Brain/Decide.hs
+++ b/Application/Brain/Decide.hs
@@ -22,7 +22,7 @@ data Plan
         , invoiceTranslation :: !Text
         }
     | SuspendScheduledMessages
-        { actionRunStateId :: !(Id ActionRunState)
+        { actionRunStateIds :: ![Id ActionRunState]
         }
     | DoNothing
     deriving (Eq, Show)

--- a/Application/Brain/Process.hs
+++ b/Application/Brain/Process.hs
@@ -16,8 +16,12 @@ import qualified Application.Twilio.View as Twilio.View
 import Generated.Types
 import IHP.ControllerPrelude
 
-processIncomingMessage :: (?modelContext :: ModelContext) => TwilioMessage -> IO ()
-processIncomingMessage twilioMessage = do
+processIncomingMessage ::
+    (?modelContext :: ModelContext) =>
+    Text ->
+    TwilioMessage ->
+    IO ()
+processIncomingMessage baseUrl twilioMessage = do
     workerPhoneNumberId <- get #id <$> fetchOne (get #fromId twilioMessage)
     botPhoneNumberId <- get #id <$> fetchOne (get #toId twilioMessage)
     workerId <- get #id <$> Person.fetchByPhoneNumber workerPhoneNumberId
@@ -30,5 +34,5 @@ processIncomingMessage twilioMessage = do
             observations <- Observe.observe Observe.IncomingMessage {..}
             let situation = Orient.orient observations
             let plan = Decide.decide situation
-            Act.act plan
+            Act.act baseUrl plan
         [] -> pure ()

--- a/Application/Timecard/ReviewRequest.hs
+++ b/Application/Timecard/ReviewRequest.hs
@@ -1,0 +1,39 @@
+module Application.Timecard.ReviewRequest where
+
+import qualified Application.Action.SendMessageAction as SendMessageAction
+import qualified Application.Timecard.AccessToken as Timecard.AccessToken
+import Generated.Types
+import IHP.ControllerPrelude
+
+scheduleRequest ::
+    (?modelContext :: ModelContext) =>
+    Text ->
+    UTCTime ->
+    Id Timecard ->
+    Text ->
+    Id PhoneNumber ->
+    Id PhoneNumber ->
+    IO SendMessageAction
+scheduleRequest baseUrl now timecardId workerName fromPhoneNumberId toPhoneNumberId = do
+    timecardAccessToken <- Timecard.AccessToken.create expiresAt timecardId
+    accessToken <- fetchOne $ get #accessTokenId timecardAccessToken
+    let link = reviewLink baseUrl (get #value accessToken)
+        sendAt = requestTime now
+        body = requestBody workerName link
+     in SendMessageAction.schedule fromPhoneNumberId toPhoneNumberId body sendAt
+  where
+    expiresAt = Timecard.AccessToken.expirationFrom now
+
+reviewLink :: Text -> Text -> Text
+reviewLink baseUrl accessToken = baseUrl <> "/ShowTimecardReview?accessToken=" <> accessToken
+
+requestTime :: UTCTime -> UTCTime
+requestTime = addUTCTime (60 * 4)
+
+requestBody :: Text -> Text -> Text
+requestBody name link =
+    "Thanks "
+        <> name
+        <> ". Here's your timecard to review and sign:\n"
+        <> link
+        <> "\n\nLet me know if you need me to make any corrections on it. Have a good weekend!"

--- a/Tests/Application/Brain/ActSpec.hs
+++ b/Tests/Application/Brain/ActSpec.hs
@@ -121,18 +121,29 @@ spec = do
 
             context "when the plan says to suspend an existing scheduled reminder" do
                 itIO "suspends scheduled messages" do
-                    actionRunState <-
+                    actionRunState1 <-
+                        newRecord @ActionRunState
+                            |> set #state ActionRunState.notStarted
+                            |> createRecord
+
+                    actionRunState2 <-
                         newRecord @ActionRunState
                             |> set #state ActionRunState.notStarted
                             |> createRecord
 
                     Act.act
                         Decide.SuspendScheduledMessages
-                            { actionRunStateId = get #id actionRunState
+                            { actionRunStateIds =
+                                [ get #id actionRunState1
+                                , get #id actionRunState2
+                                ]
                             }
 
-                    actionRunState <- fetch $ get #id actionRunState
-                    get #state actionRunState `shouldBe` ActionRunState.suspended
+                    actionRunState1 <- fetch $ get #id actionRunState1
+                    get #state actionRunState1 `shouldBe` ActionRunState.suspended
+
+                    actionRunState2 <- fetch $ get #id actionRunState2
+                    get #state actionRunState2 `shouldBe` ActionRunState.suspended
 
             context "when the plan says to do nothing" do
                 itIO "does nothing" do

--- a/Tests/Application/Brain/ActSpec.hs
+++ b/Tests/Application/Brain/ActSpec.hs
@@ -120,14 +120,14 @@ spec = do
                     get #runsAt actionRunTime `shouldBe` toUtc "2021-08-31 15:30:00 PDT"
 
             context "when the plan says to suspend an existing scheduled reminder" do
-                itIO "suspend the existing scheduled reminder" do
+                itIO "suspends scheduled messages" do
                     actionRunState <-
                         newRecord @ActionRunState
                             |> set #state ActionRunState.notStarted
                             |> createRecord
 
                     Act.act
-                        Decide.SuspendReminder
+                        Decide.SuspendScheduledMessages
                             { actionRunStateId = get #id actionRunState
                             }
 

--- a/Tests/Application/Brain/ActSpec.hs
+++ b/Tests/Application/Brain/ActSpec.hs
@@ -65,7 +65,7 @@ spec = do
                             |> createRecord
 
                     Act.act
-                        Decide.CreateTimecardEntryAndScheduleReminder
+                        Decide.CreateTimecardEntry
                             { now = toUtc "2021-08-30 15:30:00 PDT"
                             , companyTimeZone = toTimeZone "PDT"
                             , workerId = get #id worker

--- a/Tests/Application/Brain/DecideSpec.hs
+++ b/Tests/Application/Brain/DecideSpec.hs
@@ -121,11 +121,17 @@ spec = do
                                         }
                             , reminder =
                                 Orient.ReminderIsScheduled
-                                    { actionRunStateId = "50000000-0000-0000-0000-000000000000"
+                                    { actionRunStateIds =
+                                        [ "50000000-0000-0000-0000-000000000000"
+                                        , "60000000-0000-0000-0000-000000000000"
+                                        ]
                                     }
                             }
                         `shouldBe` Decide.SuspendScheduledMessages
-                            { actionRunStateId = "50000000-0000-0000-0000-000000000000"
+                            { actionRunStateIds =
+                                [ "50000000-0000-0000-0000-000000000000"
+                                , "60000000-0000-0000-0000-000000000000"
+                                ]
                             }
 
             context "and the update is for multiple jobs" do
@@ -141,11 +147,17 @@ spec = do
                             , update = Orient.UpdateIsForMultipleJobs
                             , reminder =
                                 Orient.ReminderIsScheduled
-                                    { actionRunStateId = "50000000-0000-0000-0000-000000000000"
+                                    { actionRunStateIds =
+                                        [ "50000000-0000-0000-0000-000000000000"
+                                        , "60000000-0000-0000-0000-000000000000"
+                                        ]
                                     }
                             }
                         `shouldBe` Decide.SuspendScheduledMessages
-                            { actionRunStateId = "50000000-0000-0000-0000-000000000000"
+                            { actionRunStateIds =
+                                [ "50000000-0000-0000-0000-000000000000"
+                                , "60000000-0000-0000-0000-000000000000"
+                                ]
                             }
 
             context "and the details don't match in the update" do
@@ -161,11 +173,17 @@ spec = do
                             , update = Orient.UpdateDetailsDoNotMatch
                             , reminder =
                                 Orient.ReminderIsScheduled
-                                    { actionRunStateId = "50000000-0000-0000-0000-000000000000"
+                                    { actionRunStateIds =
+                                        [ "50000000-0000-0000-0000-000000000000"
+                                        , "60000000-0000-0000-0000-000000000000"
+                                        ]
                                     }
                             }
                         `shouldBe` Decide.SuspendScheduledMessages
-                            { actionRunStateId = "50000000-0000-0000-0000-000000000000"
+                            { actionRunStateIds =
+                                [ "50000000-0000-0000-0000-000000000000"
+                                , "60000000-0000-0000-0000-000000000000"
+                                ]
                             }
 
             context "and the message is not an update" do
@@ -181,11 +199,17 @@ spec = do
                             , update = Orient.MessageIsNotAnUpdate
                             , reminder =
                                 Orient.ReminderIsScheduled
-                                    { actionRunStateId = "50000000-0000-0000-0000-000000000000"
+                                    { actionRunStateIds =
+                                        [ "50000000-0000-0000-0000-000000000000"
+                                        , "60000000-0000-0000-0000-000000000000"
+                                        ]
                                     }
                             }
                         `shouldBe` Decide.SuspendScheduledMessages
-                            { actionRunStateId = "50000000-0000-0000-0000-000000000000"
+                            { actionRunStateIds =
+                                [ "50000000-0000-0000-0000-000000000000"
+                                , "60000000-0000-0000-0000-000000000000"
+                                ]
                             }
 
         context "when the situation has a suspended reminder" do

--- a/Tests/Application/Brain/DecideSpec.hs
+++ b/Tests/Application/Brain/DecideSpec.hs
@@ -34,7 +34,7 @@ spec = do
                                         }
                             , reminder = Orient.ReminderIsNotScheduled
                             }
-                        `shouldBe` Decide.CreateTimecardEntryAndScheduleReminder
+                        `shouldBe` Decide.CreateTimecardEntry
                             { now = toUtc "2021-08-30 15:20:00 PDT"
                             , companyTimeZone = toTimeZone "PDT"
                             , workerId = "10000000-0000-0000-0000-000000000000"

--- a/Tests/Application/Brain/DecideSpec.hs
+++ b/Tests/Application/Brain/DecideSpec.hs
@@ -98,7 +98,7 @@ spec = do
 
         context "when the situation does have a scheduled reminder" do
             context "and the update is for a single job" do
-                it "returns a plan to suspend the scheduled reminder" do
+                it "returns a plan to suspend scheduled messages" do
                     Decide.decide
                         Orient.Situation
                             { now = toUtc "2021-08-30 15:20:00 PDT"
@@ -124,12 +124,12 @@ spec = do
                                     { actionRunStateId = "50000000-0000-0000-0000-000000000000"
                                     }
                             }
-                        `shouldBe` Decide.SuspendReminder
+                        `shouldBe` Decide.SuspendScheduledMessages
                             { actionRunStateId = "50000000-0000-0000-0000-000000000000"
                             }
 
             context "and the update is for multiple jobs" do
-                it "returns a plan to suspend the scheduled reminder" do
+                it "returns a plan to suspend scheduled messages" do
                     Decide.decide
                         Orient.Situation
                             { now = toUtc "2021-08-30 15:20:00 PDT"
@@ -144,12 +144,12 @@ spec = do
                                     { actionRunStateId = "50000000-0000-0000-0000-000000000000"
                                     }
                             }
-                        `shouldBe` Decide.SuspendReminder
+                        `shouldBe` Decide.SuspendScheduledMessages
                             { actionRunStateId = "50000000-0000-0000-0000-000000000000"
                             }
 
             context "and the details don't match in the update" do
-                it "returns a plan to suspend the scheduled reminder" do
+                it "returns a plan to suspend scheduled messages" do
                     Decide.decide
                         Orient.Situation
                             { now = toUtc "2021-08-30 15:20:00 PDT"
@@ -164,12 +164,12 @@ spec = do
                                     { actionRunStateId = "50000000-0000-0000-0000-000000000000"
                                     }
                             }
-                        `shouldBe` Decide.SuspendReminder
+                        `shouldBe` Decide.SuspendScheduledMessages
                             { actionRunStateId = "50000000-0000-0000-0000-000000000000"
                             }
 
             context "and the message is not an update" do
-                it "returns a plan to suspend the scheduled reminder" do
+                it "returns a plan to suspend scheduled messages" do
                     Decide.decide
                         Orient.Situation
                             { now = toUtc "2021-08-30 15:20:00 PDT"
@@ -184,7 +184,7 @@ spec = do
                                     { actionRunStateId = "50000000-0000-0000-0000-000000000000"
                                     }
                             }
-                        `shouldBe` Decide.SuspendReminder
+                        `shouldBe` Decide.SuspendScheduledMessages
                             { actionRunStateId = "50000000-0000-0000-0000-000000000000"
                             }
 

--- a/Tests/Application/Brain/OrientSpec.hs
+++ b/Tests/Application/Brain/OrientSpec.hs
@@ -87,7 +87,7 @@ spec = do
                                 }
                     , reminder =
                         Orient.ReminderIsScheduled
-                            { actionRunStateId = "20000000-0000-0000-0000-000000000000"
+                            { actionRunStateIds = ["20000000-0000-0000-0000-000000000000"]
                             }
                     }
 
@@ -403,25 +403,7 @@ spec = do
                     `shouldBe` Orient.MessageIsNotAnUpdate
 
     describe "buildReminder" do
-        it "returns ReminderIsScheduled when the first send message action is not started" do
-            Orient.buildReminder
-                [ SendMessageAction.T
-                    { id = "10000000-0000-0000-0000-000000000000"
-                    , actionRunStateId = "20000000-0000-0000-0000-000000000000"
-                    , state = ActionRunState.notStarted
-                    , runsAt = toUtc "2021-09-01 14:00:00 PDT"
-                    , body = "Did some good work."
-                    , fromId = "30000000-0000-0000-0000-000000000000"
-                    , fromNumber = "+15555555555"
-                    , toId = "40000000-0000-0000-0000-000000000000"
-                    , toNumber = "+16666666666"
-                    }
-                ]
-                `shouldBe` Orient.ReminderIsScheduled
-                    { actionRunStateId = "20000000-0000-0000-0000-000000000000"
-                    }
-
-        it "returns ReminderIsSuspended when the first send message action is suspended" do
+        it "returns ReminderIsScheduled when any message action is not suspended" do
             Orient.buildReminder
                 [ SendMessageAction.T
                     { id = "10000000-0000-0000-0000-000000000000"
@@ -434,10 +416,50 @@ spec = do
                     , toId = "40000000-0000-0000-0000-000000000000"
                     , toNumber = "+16666666666"
                     }
+                , SendMessageAction.T
+                    { id = "50000000-0000-0000-0000-000000000000"
+                    , actionRunStateId = "60000000-0000-0000-0000-000000000000"
+                    , state = ActionRunState.notStarted
+                    , runsAt = toUtc "2021-09-01 14:00:00 PDT"
+                    , body = "Did some good work."
+                    , fromId = "70000000-0000-0000-0000-000000000000"
+                    , fromNumber = "+15555555555"
+                    , toId = "80000000-0000-0000-0000-000000000000"
+                    , toNumber = "+16666666666"
+                    }
+                ]
+                `shouldBe` Orient.ReminderIsScheduled
+                    { actionRunStateIds = ["60000000-0000-0000-0000-000000000000"]
+                    }
+
+        it "returns ReminderIsSuspended when all send message actions are suspended" do
+            Orient.buildReminder
+                [ SendMessageAction.T
+                    { id = "10000000-0000-0000-0000-000000000000"
+                    , actionRunStateId = "20000000-0000-0000-0000-000000000000"
+                    , state = ActionRunState.suspended
+                    , runsAt = toUtc "2021-09-01 14:00:00 PDT"
+                    , body = "Did some good work."
+                    , fromId = "30000000-0000-0000-0000-000000000000"
+                    , fromNumber = "+15555555555"
+                    , toId = "40000000-0000-0000-0000-000000000000"
+                    , toNumber = "+16666666666"
+                    }
+                , SendMessageAction.T
+                    { id = "50000000-0000-0000-0000-000000000000"
+                    , actionRunStateId = "60000000-0000-0000-0000-000000000000"
+                    , state = ActionRunState.suspended
+                    , runsAt = toUtc "2021-09-01 14:00:00 PDT"
+                    , body = "Did some good work."
+                    , fromId = "70000000-0000-0000-0000-000000000000"
+                    , fromNumber = "+15555555555"
+                    , toId = "80000000-0000-0000-0000-000000000000"
+                    , toNumber = "+16666666666"
+                    }
                 ]
                 `shouldBe` Orient.ReminderIsSuspended
 
-        it "returns ReminderIsNotScheduled when the first send message action is canceled" do
+        it "returns ReminderIsNotScheduled when the only send message action is canceled" do
             Orient.buildReminder
                 [ SendMessageAction.T
                     { id = "10000000-0000-0000-0000-000000000000"
@@ -452,6 +474,9 @@ spec = do
                     }
                 ]
                 `shouldBe` Orient.ReminderIsNotScheduled
+
+        it "returns ReminderIsNotScheduled when there are no scheduled messages" do
+            Orient.buildReminder [] `shouldBe` Orient.ReminderIsNotScheduled
 
         it "ignores extra send message actions (we are choosing not to handle this case right now)" do
             Orient.buildReminder
@@ -479,7 +504,7 @@ spec = do
                     }
                 ]
                 `shouldBe` Orient.ReminderIsScheduled
-                    { actionRunStateId = "20000000-0000-0000-0000-000000000000"
+                    { actionRunStateIds = ["20000000-0000-0000-0000-000000000000"]
                     }
 
         it "returns ReminderIsNotScheduled when there are no send message actions" do

--- a/Tests/Application/Brain/ProcessSpec.hs
+++ b/Tests/Application/Brain/ProcessSpec.hs
@@ -81,7 +81,9 @@ spec = do
                         |> set #body "Hi!"
                         |> createRecord
 
-                Brain.Process.processIncomingMessage twilioMessage
+                Brain.Process.processIncomingMessage
+                    "https://timecard.company.com"
+                    twilioMessage
 
                 actionRunState <- fetch $ get #actionRunStateId sendMessageAction
                 get #state actionRunState `shouldBe` ActionRunState.suspended

--- a/Tests/Application/Timecard/ReviewRequestSpec.hs
+++ b/Tests/Application/Timecard/ReviewRequestSpec.hs
@@ -1,0 +1,90 @@
+module Tests.Application.Timecard.ReviewRequestSpec where
+
+import qualified Application.Timecard.ReviewRequest as ReviewRequest
+import Generated.Types
+import IHP.ControllerPrelude
+import IHP.Environment
+import IHP.Test.Mocking
+import Test.Hspec
+import Tests.Support
+import Text.Read (read)
+
+spec :: Spec
+spec = do
+    describe "reviewLink" do
+        it "returns the full URL for a timecard review" do
+            ReviewRequest.reviewLink "https://timecard.company.com" "secrettoken"
+                `shouldBe` "https://timecard.company.com/ShowTimecardReview?accessToken=secrettoken"
+
+    describe "requestTime" do
+        it "returns a time 4 minutes after the given time" do
+            ReviewRequest.requestTime (toUtc "2021-09-20 00:00:00 PDT")
+                `shouldBe` toUtc "2021-09-20 00:04:00 PDT"
+
+    describe "requestBody" do
+        it "returns the body of the timecard review request" do
+            ReviewRequest.requestBody "Laura" "https://fake.com"
+                `shouldBe` "Thanks Laura. Here's your timecard to review and sign:\nhttps://fake.com\n\nLet me know if you need me to make any corrections on it. Have a good weekend!"
+
+    describe "scheduleRequest" do
+        beforeAll (testConfig >>= mockContext RootApplication) do
+            itIO "schedules a request for a timecard review" do
+                bot <-
+                    newRecord @Person
+                        |> set #firstName "Tim"
+                        |> set #lastName "Eckard"
+                        |> set #goesBy "Tim the Bot"
+                        |> createRecord
+
+                botPhoneNumber <-
+                    newRecord @PhoneNumber
+                        |> set #number "+15555555555"
+                        |> createRecord
+
+                newRecord @PhoneContact
+                    |> set #personId (get #id bot)
+                    |> set #phoneNumberId (get #id botPhoneNumber)
+                    |> createRecord
+
+                worker <-
+                    newRecord @Person
+                        |> set #firstName "Laura"
+                        |> set #lastName "Wilder"
+                        |> set #goesBy "Laura"
+                        |> createRecord
+
+                workerPhoneNumber <-
+                    newRecord @PhoneNumber
+                        |> set #number "+16666666666"
+                        |> createRecord
+
+                newRecord @PhoneContact
+                    |> set #personId (get #id worker)
+                    |> set #phoneNumberId (get #id workerPhoneNumber)
+                    |> createRecord
+
+                timecard <-
+                    newRecord @Timecard
+                        |> set #personId (get #id worker)
+                        |> set #weekOf (toDay "2021-09-13")
+                        |> createRecord
+
+                sendMessageAction <-
+                    ReviewRequest.scheduleRequest
+                        "https://fake.com"
+                        (toUtc "2021-09-17 15:30:00 PDT")
+                        (get #id timecard)
+                        "Mrs. Laura"
+                        (get #id botPhoneNumber)
+                        (get #id workerPhoneNumber)
+
+                timecardAccessToken <- query @TimecardAccessToken |> filterWhere (#timecardId, get #id timecard) |> fetchOne
+                accessToken <- fetch $ get #accessTokenId timecardAccessToken
+                let accessTokenValue = get #value accessToken
+
+                get #fromId sendMessageAction `shouldBe` get #id botPhoneNumber
+                get #toId sendMessageAction `shouldBe` get #id workerPhoneNumber
+                get #body sendMessageAction
+                    `shouldBe` "Thanks Mrs. Laura. Here's your timecard to review and sign:\nhttps://fake.com/ShowTimecardReview?accessToken="
+                    <> accessTokenValue
+                    <> "\n\nLet me know if you need me to make any corrections on it. Have a good weekend!"

--- a/Web/Controller/Communications.hs
+++ b/Web/Controller/Communications.hs
@@ -371,9 +371,6 @@ instance Controller CommunicationsController where
         selectedPersonPhoneNumber <- PhoneNumber.fetchByPerson selectedPersonId
 
         now <- getCurrentTime
-        let expiresAt = Timecard.AccessToken.expirationFrom now
-        Timecard.AccessToken.create expiresAt timecardId
-
         ReviewRequest.scheduleRequest
             (baseUrl $ getFrameworkConfig ?context)
             now

--- a/Web/Controller/Communications.hs
+++ b/Web/Controller/Communications.hs
@@ -13,6 +13,7 @@ import qualified Application.Timecard.Entry as Timecard.Entry
 import qualified Application.Timecard.EntryMessage as Timecard.EntryMessage
 import qualified Application.Timecard.EntryRequest as Timecard.EntryRequest
 import qualified Application.Timecard.Query as Timecard.Query
+import qualified Application.Timecard.ReviewRequest as ReviewRequest
 import qualified Application.Timecard.Timecard as Timecard
 import qualified Application.Timecard.View as Timecard.View
 import qualified Application.Twilio.Query as Twilio.Query
@@ -20,8 +21,9 @@ import qualified Application.Twilio.TwilioMessage as TwilioMessage
 import qualified Application.Twilio.View as Twilio.View
 import Data.Functor ((<&>))
 import Data.Text (strip)
+import IHP.FrameworkConfig (baseUrl)
 import Text.Read (read)
-import Web.Controller.Prelude
+import Web.Controller.Prelude hiding (baseUrl)
 import Web.View.Communications.Index
 
 instance Controller CommunicationsController where
@@ -362,9 +364,23 @@ instance Controller CommunicationsController where
         let timecardId = param @(Id Timecard) "timecardId"
         let column = Just $ columnToParam MessagesColumn
 
+        botId <- Person.fetchBotId
+        botPhoneNumber <- PhoneNumber.fetchByPerson botId
+
+        selectedPerson <- fetch selectedPersonId
+        selectedPersonPhoneNumber <- PhoneNumber.fetchByPerson selectedPersonId
+
         now <- getCurrentTime
         let expiresAt = Timecard.AccessToken.expirationFrom now
         Timecard.AccessToken.create expiresAt timecardId
+
+        ReviewRequest.scheduleRequest
+            (baseUrl $ getFrameworkConfig ?context)
+            now
+            timecardId
+            (get #goesBy selectedPerson)
+            (get #id botPhoneNumber)
+            (get #id selectedPersonPhoneNumber)
 
         redirectTo CommunicationsPersonSelectionAction {..}
 

--- a/Web/Job/FetchEntityPrediction.hs
+++ b/Web/Job/FetchEntityPrediction.hs
@@ -9,8 +9,9 @@ import Application.Service.Validation (validateAndCreate)
 import qualified Application.Twilio.TwilioMessageEntity as TwilioMessageEntity
 import qualified Application.VertexAi.Client as Client
 import qualified Application.VertexAi.VertexAiEntityPrediction as VertexAiEntityPrediction
+import IHP.FrameworkConfig (baseUrl)
 import qualified IHP.Log as Log
-import Web.Controller.Prelude
+import Web.Controller.Prelude hiding (baseUrl)
 
 instance Job FetchEntityPredictionJob where
     maxAttempts = 1
@@ -22,7 +23,9 @@ instance Job FetchEntityPredictionJob where
         Log.info ("Fetching entity predictions for TwilioMessage: " <> show twilioMessageId)
         fetchEntityPredictions now Client.config twilioMessage >> pure ()
 
-        Brain.Process.processIncomingMessage twilioMessage
+        Brain.Process.processIncomingMessage
+            (baseUrl $ getFrameworkConfig ?context)
+            twilioMessage
 
 fetchEntityPredictions ::
     (?modelContext :: ModelContext) =>


### PR DESCRIPTION
This PR "closes the loop" on the timecard info collection process. The last piece of the puzzle was to automatically send out a response on Friday asking crew members to sign their timecard. That's what this PR is all about.

So in the basic case where a crew member responded to all of the messages with the right info, there should be no manual work required to collect timecard info and sign the timecard at the end of the week.

https://vimeo.com/608602704/3b3fe092ed
https://vimeo.com/608611255/ff0abf1dab